### PR TITLE
Update AppHead to use `title` prop

### DIFF
--- a/shared/app-head/app-head.tsx
+++ b/shared/app-head/app-head.tsx
@@ -1,17 +1,17 @@
-import React, {FC} from "react";
+import React, { FC } from "react";
 import Head from "next/head";
 
 interface AppHeadProps {
-    title?: String
+  title?: string;
 }
 
-const AppHead: FC<AppHeadProps> = ({ title }) => {
+const AppHead: FC<AppHeadProps> = ({ title = "جستجوی اطلاعات تماس" }) => {
   return (
     <Head>
-      <title>پیش شماره | جستجوی اطلاعات تماس</title>
+      <title>پیش‌شماره | {title}</title>
       <meta name="description" content="پیش شماره - جستجوی اطلاعات تماس" />
     </Head>
   );
-}
+};
 
 export default AppHead;


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Feature

## What is the new behavior?
- Now AppHead component accepts an optional `title` prop and uses it as a subtitle for the website.
 if prop does not exist the app will use a general subtitle instead.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No